### PR TITLE
Fix colors for themes that use the default terminal colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/json5": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
-			"integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA=="
-		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -596,14 +591,6 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -649,7 +636,8 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
     "vscode-test": "^1.2.0"
   },
   "dependencies": {
-    "@types/json5": "0.0.30",
-    "change-case": "^4.1.1",
-    "json5": "^2.1.3"
+    "change-case": "^4.1.1"
   }
 }

--- a/src/convertThemeToScheme.ts
+++ b/src/convertThemeToScheme.ts
@@ -10,6 +10,8 @@ export function convertThemeToScheme(theme: any, name: string) {
     brightMagenta: "brightPurple",
   });
 
+  const exclude = ["border"];
+
   const scheme = {
     name: name,
     background: colors["editor.background"],
@@ -38,6 +40,7 @@ export function convertThemeToScheme(theme: any, name: string) {
 
           return [key, value];
         })
+        .filter(([key]) => !exclude.includes(key))
     ),
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { parse as parseJson } from "json5";
 import { convertThemeToScheme } from "./convertThemeToScheme";
 
 async function promptThemeName() {
@@ -16,7 +15,11 @@ async function getActiveColorTheme(): Promise<any | undefined> {
     return;
   }
 
-  return parseJson(editor.document.getText());
+  // Uncomment lines that are commented so that if we are missing values, we will get the
+  // defaults instead
+  const themeText = editor.document.getText().replace(/\/\//g, "");
+
+  return JSON.parse(themeText);
 }
 
 async function replaceEditorText(text: string) {


### PR DESCRIPTION
It turns out the "workbench.action.generateColorTheme" command includes the default theme colors as commented out lines of JSON. This fix uncomments them and then performs the same conversion. This way any theme colors not explicitly defined by the theme are still picked up.

This also removes the need I had for the `json5` dependency as I no longer need to parse JSON with comments.

Fixes #1 